### PR TITLE
fix： 修复由于同一主机地址下的不同端口的应用共享cookies，造成session冲突

### DIFF
--- a/magic_dash/templates/magic-dash-pro/configs/base_config.py
+++ b/magic_dash/templates/magic-dash-pro/configs/base_config.py
@@ -13,6 +13,13 @@ class BaseConfig:
     # 应用密钥
     app_secret_key: str = "magic-dash-pro-demo"
 
+    # 应用会话cookie名称
+    # 由于同一主机地址下的不同端口，在浏览器中会
+    # 共享cookies，因此在同一主机地址下部署多套基于
+    # magic-dash-pro模板开发的独立项目时，请为各个项目
+    # 设置不同的app_session_cookie_name
+    app_session_cookie_name: str = "magic_dash_pro_session"
+
     # 浏览器最低版本限制规则
     min_browser_versions: List[dict] = [
         {"browser": "Chrome", "version": 88},

--- a/magic_dash/templates/magic-dash-pro/server.py
+++ b/magic_dash/templates/magic-dash-pro/server.py
@@ -18,7 +18,8 @@ app = dash.Dash(
 server = app.server
 
 # 设置应用密钥
-app.server.secret_key = BaseConfig.app_secret_key
+app.server.config["SECRET_KEY"] = BaseConfig.app_secret_key
+app.server.config["SESSION_COOKIE_NAME"] = BaseConfig.app_session_cookie_name
 
 # 为当前应用添加flask-login用户登录管理
 login_manager = LoginManager()


### PR DESCRIPTION
修复session冲突造成用户失效

复现场景：
1. 在同一个主机地址的不同端口部署应用（127.0.0.1:8050  127.0.0.1:8090）
2. 需要使用不同的数据库，使用不同的用户系统
3. `BaseConfig.app_secret_key` 设置不同值（可选）

现象：
1.  应用A的用户登录
2. 应用B的用户登录
3. 应用A用户被踢，跳转登录页

原因：
1. flask默认不会设置cookie的domain
2. 浏览器Cookie默认行为
当没有明确指定 domain 和 path 时，浏览器会使用默认规则：
  Domain: 默认为当前请求的主机名（127.0.0.1）
  Path: 默认为当前请求的路径（通常是 /）
3. 同域不同端口的特殊情况
虽然 127.0.0.1:8090 和 127.0.0.1:8050 在同源策略中被认为是不同源（因为端口不同），但是：
Cookie的domain匹配规则更宽松
当cookie的domain设置为 127.0.0.1（没有端口）时，浏览器会将其应用到该IP的所有端口
这是浏览器的历史行为，与XMLHttpRequest的同源策略不同
4. 2应用共享了cookies，造成了session名称的冲突
5. 应用B用户登录，造成seesion被改写
6. 应用A中查询不到用户，返回AnonymousUserMixin，引起重登录
